### PR TITLE
allow turning off notifications for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var WebpackErrorNotificationPlugin = require('webpack-error-notification');
 // ...
   module: {
     plugins: [
-      new WebpackErrorNotificationPlugin(/* strategy */),
+      new WebpackErrorNotificationPlugin(/* strategy */, /* options */),
     ]
   },
 // ...
@@ -56,3 +56,5 @@ notification CLI tool of choice.
 
 Main idea here is that, preferrably, people on your team shouldn't have to
 customize webpack config to be able to see notifications.
+
+If you do not want to notify warnings, you can provide `{ notifyWarnings: false }` as options.

--- a/index.js
+++ b/index.js
@@ -11,9 +11,10 @@ var STRATEGIES = {
 };
 
 
-function WebpackErrorNotificationPlugin(strategy) {
+function WebpackErrorNotificationPlugin(strategy, opts) {
     this.lastBuildSucceeded = false;
     this.notifier = null;
+    this.opts = opts || { notifyWarnings: true };
 
     if (typeof strategy === 'function') {
         this.notifier = strategy;
@@ -32,7 +33,8 @@ function WebpackErrorNotificationPlugin(strategy) {
 
 WebpackErrorNotificationPlugin.prototype.compileMessage = function(stats) {
     var error;
-    if (stats.hasWarnings()) {
+    if (stats.hasWarnings() &&
+        this.opts.notifyWarnings) {
         error = stats.compilation.warnings[0];
     }
     if (stats.hasErrors()) {


### PR DESCRIPTION
Hey :)

Just started using your plugin at one of the projects, but the tiny problem is that it notifies on warnings. Unfortunately, I'm having a bit of old, imperfect code that would take some time to get rid of warnings.

What do you think about adding way for passing extra options and allowing some flexibility here ? :)
