### PR TITLE
Remove ANSI color symbols from message for all platforms. Ecsape HTML…

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,28 @@ var execFile = require('child_process').execFile;
 
 var STRATEGIES = {
     'darwin': function(msg) {
+        msg = escapeColors(msg);
         execFile('terminal-notifier', ['-title', 'Webpack', '-message', msg]);
     },
     'linux': function(msg) {
+        msg = escapeColors(msg);
+        msg = escapeHtml(msg);
         execFile('notify-send', ['Webpack', msg]);
     }
 };
 
+function escapeColors(msg) {
+    return msg.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
+}
+
+function escapeHtml(unsafe) {
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+ }
 
 function WebpackErrorNotificationPlugin(strategy, opts) {
     this.lastBuildSucceeded = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-error-notification",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Use system notification to inform developer about compilation error",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
… for linux, because KDE notifier interprets it.