### PR TITLE
Webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,12 @@ WebpackErrorNotificationPlugin.prototype.apply = function(compiler) {
     if (this.notifier === null) {
         console.log('Failed to set error notification.');
     } else {
-        compiler.plugin('done', this.compilationDone.bind(this));
+        if (typeof compiler.hooks === 'undefined') {
+            // Backwards-compatible for pre webpack-4
+            compiler.plugin('done', this.compilationDone.bind(this));
+        } else {
+            compiler.hooks.done.tap("webpack-error-notification", this.compilationDone.bind(this))
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-error-notification",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Use system notification to inform developer about compilation error",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "peerDependencies": {
+    "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+  },
   "keywords": [
     "webpack",
     "build"


### PR DESCRIPTION
Once webpack is upgraded to v4, it began emitting deprecation warnings:

`(node:90791) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead`

Once I added `process.traceDeprecation = true;` to `webpack.config.js` I found that this plugin was the culprit. 

```
(node:90791) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
    at WebpackErrorNotificationPlugin.apply (./node_modules/webpack-error-notification/index.js:87:18)
    at webpack (./node_modules/webpack/lib/webpack.js:37:12)
    at processOptions (./node_modules/webpack-cli/bin/cli.js:441:16)
    at yargs.parse (./node_modules/webpack-cli/bin/cli.js:528:3)
    at Object.parse (./node_modules/webpack-cli/node_modules/yargs/yargs.js:563:18)
    at ./node_modules/webpack-cli/bin/cli.js:219:8
    at Object.<anonymous> (./node_modules/webpack-cli/bin/cli.js:530:3)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (./node_modules/webpack/bin/webpack.js:165:2)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```

This warning doesn't break the funcitonality of the plugin. This PR updates the plugin to use the new  [webpack 4 compiler hooks](https://webpack.js.org/api/compiler-hooks/) while still maintaining backwards compatibility for older webpack versions.